### PR TITLE
Set warn and error to the correct numbers.

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -27,8 +27,8 @@ var getMessageLevel = function (winstonLevel) {
         "debug" : 7,
         "info" : 6,
         "notice": 5,
-        "warn": 3,
-        "error" : 2
+        "warn": 4,
+        "error" : 3
     };
 
     if (typeof winstonLevel === "number") {


### PR DESCRIPTION
Warn shows up in Graylog as Error and Error shows up as Crit. (Graylog2 0.9.6)

It looks like the right levels get passed into winston-graylog2 but I think it's just the mapping that's wrong.

Looking at some other modules seems to confirm what I'm seeing:

https://github.com/fouasnon/winston-graylog2/blob/master/lib/syslog-codes.js
https://github.com/Graylog2/gelf-rb/blob/master/lib/gelf/severity.rb

This reproduces the issue on my system:

``` js
var winston = require('winston');
var logger = new (winston.Logger)();

var settings = {
  console_loglevel: 'info',
  graylog2: {
    level: 'debug'
  }
};

logger.setLevels({
  debug: 0,
  info: 1,
  warn: 3,
  error: 4
});
logger.add(winston.transports.Console, {
  level: settings.console_loglevel
});
var Graylog2 = require('winston-graylog2').Graylog2;
logger.add(Graylog2, {
  level: settings.graylog2.level
});

logger.debug('Testing debug');
logger.info('Testing info');
logger.warn('Testing warn');
logger.error('Testing error');
```

I set the initial log levels because of [this bug](https://github.com/flatiron/winston/issues/89) which makes the rest of the loggers respect the minimum `level` option (including this module).
