### PR TITLE
errors bubbling down to uncaughtException

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -10,6 +10,8 @@ var Graylog2 = exports.Graylog2 = winston.transports.Graylog2 = function (option
     this.level = options.level || 'info';
     this.silent     = options.silent     || false;
     this.handleExceptions = options.handleExceptions || false;
+    this.udpClient = dgram.createSocket('udp4');
+    this.udpClient.on('error', function (err) { util.error(err) }) // handle any suprise errors
 
     this.graylogHost = options.graylogHost || 'localhost';
     this.graylogPort = options.graylogPort || 12201;
@@ -67,16 +69,8 @@ Graylog2.prototype.log = function (level, msg, meta, callback) {
         return callback(new Error("Log message size > 8192 bytes not supported."), null);
     }
 
-    try {
-        var udpClient = dgram.createSocket('udp4');
-        udpClient.send(compressedMessage, 0, compressedMessage.length, self.graylogPort, self.graylogHost, function (err, bytes) {
-            if (err) {
-                return callback(err, null);
-            }
-            udpClient.close();
-            return callback(null, true);
-        });
-    } catch (e) {
-        return callback(e, null);
-    }
+    this.udpClient.send(compressedMessage, 0, compressedMessage.length, self.graylogPort, self.graylogHost, function (err, bytes) {
+        if (err) callback(err, null);
+        else callback(null, true);
+    });
 };


### PR DESCRIPTION
this addresses issue #6, also pulls try/catch out since that doesn't help at all with async, and reuses the udpclient, tested in production and seems to check out
