### PR TITLE
support all winston logging types

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -26,20 +26,24 @@ var Graylog2 = exports.Graylog2 = winston.transports.Graylog2 = function (option
 util.inherits(Graylog2, winston.Transport);
 
 var getMessageLevel = function (winstonLevel) {
-    var mappings = {
-        "verbose": 7,
-        "silly": 7,
-        "debug" : 7,
-        "info" : 6,
-        "notice": 5,
-        "warn": 4,
-        "error" : 3
-    };
-
-    if (typeof winstonLevel === "number") {
-        return winstonLevel;
+    switch (winstonLevel) {                                                                                                   
+        case 'silly':
+        case 'debug': return 7
+        case 'verbose':
+        case 'data':
+        case 'prompt':
+        case 'input':
+        case 'info': return 6
+        case 'help':
+        case 'notice': return 5
+        case 'warn':
+        case 'warning': return 4
+        case 'error': return 3
+        case 'crit': return 2
+        case 'alert': return 1
+        case 'emerg': return 0
+        default: return 6
     }
-    return mappings[winstonLevel] || 6;
 };
 
 Graylog2.prototype.log = function (level, msg, meta, callback) {


### PR DESCRIPTION
currently, this module will just use level 6 when it doesn't understand the log type and just supports npm style, this adds cli and syslog styles and accurately supports all 8 syslog levels.
