### PR TITLE
Allow milliseconds in messages sent to graylog2

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -55,7 +55,7 @@ Graylog2.prototype.log = function (level, msg, meta, callback) {
 
     // Must be in this format: https://github.com/Graylog2/graylog2-docs/wiki/GELF
     message.version = "1.0";
-    message.timestamp = +new Date()/1000 >> 0;
+    message.timestamp = +new Date()/1000;
     message.host = self.graylogHostname;
     message.facility = self.graylogFacility;
     message.short_message = msg;


### PR DESCRIPTION
The milliseconds were being explicitly removed. I'm not sure for what reason.  In any case, this change will allow millisecond precision in the log messages.
