### PR TITLE
do not throw error on circular objects

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -69,8 +69,11 @@ Graylog2.prototype.log = function (level, msg, meta, callback) {
             }
         }
     }
-
-    var compressedMessage = compress(new Buffer(JSON.stringify(message)));
+    var flatMessage = util.inspect(message,{
+        depth: 4,
+        showHidden: true
+    });
+    var compressedMessage = compress(new Buffer(flatMessage));
 
     if (compressedMessage.length > 8192) {
         return callback(new Error("Log message size > 8192 bytes not supported."), null);

--- a/test/winston-graylog2-test.js
+++ b/test/winston-graylog2-test.js
@@ -21,6 +21,15 @@ vows.describe('winston-graylog2').addBatch({
    "the log() method": helpers.testNpmLevels(transport, "should log messages to Graylog2", function (ign, err, logged) {
      assert.isTrue(!err);
      assert.isTrue(logged);
-   })
+   }),
+   "should not throw error on circular objects": function () {
+      var a = {};
+      var b = {};
+      a.b = b;
+      b.a = a;
+      assert.doesNotThrow(function(){
+        transport.log( "error", a, b, function(){});
+      }, Error );
+   }
  }
 }).export(module);


### PR DESCRIPTION
If you pass to logger.log as message or as meta a circular object, winston-graylog2 will throw an error.

For example mysql errors are circular objects.

This patch is using `util.inspect` instead of `JSON.stringify` to solve this problem.
