### PR TITLE
Better handling of metadata

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -1,8 +1,16 @@
 'use strict';
-var util = require('util'),
-  winston = require('winston'),
-  graylog2 = require('graylog2');
 
+var util = require('util');
+var winston = require('winston');
+var graylog2 = require('graylog2');
+var _ = require('lodash');
+
+/**
+ * Remaping winston level on greylog
+ * 
+ * @param  {String} winstonLevel
+ * @return {String}
+ */
 function getMessageLevel(winstonLevel) {
   var levels = {
     emerg: 'emergency',
@@ -16,6 +24,36 @@ function getMessageLevel(winstonLevel) {
   };
 
   return levels[winstonLevel] || levels.info;
+}
+
+
+/**
+ * Preparing metadata for graylog
+ * If we send a javascript `Error` object
+ * to gray log we'll end up with the
+ * `[object Object]` string.
+ * To have our infos we need to get the stack out of the error.
+ * Here we remap metadata to handle this kind of situation
+ * 
+ * @param  {Object} meta
+ * @return {Object}
+ */
+function prepareMeta(meta) {
+  meta = meta || {};
+  
+  if (meta instanceof Error) {
+    meta = {error: meta.stack};
+  } else if (typeof meta === 'object') {
+    meta = _.mapValues(meta, function(value) {
+      if (value instanceof Error) {
+        return value.stack;
+      }
+
+      return value;
+    });
+  }
+
+  return meta;
 }
 
 var Graylog2 = winston.transports.Graylog2 = function(options) {
@@ -42,6 +80,8 @@ var Graylog2 = winston.transports.Graylog2 = function(options) {
 util.inherits(Graylog2, winston.Transport);
 
 Graylog2.prototype.log = function(level, msg, meta, callback) {
+  meta = prepareMeta(meta);
+
   this.graylog2[getMessageLevel(level)](msg, meta);
   callback(null, true);
 };

--- a/package.json
+++ b/package.json
@@ -44,8 +44,9 @@
     "graylog2"
   ],
   "dependencies": {
-    "winston": "^0.7.3",
-    "graylog2": "^0.1.3"
+    "graylog2": "^0.1.3",
+    "lodash": "^3.1.0",
+    "winston": "^0.7.3"
   },
   "main": "./lib/winston-graylog2",
   "scripts": {


### PR DESCRIPTION
Fixing and issue that would cause a metadata to be logged as `[object Object]` in case an error object