### PR TITLE
upgrade winston

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "graylog2": "^0.1.3",
     "lodash": "^3.1.0",
-    "winston": "^0.7.3"
+    "winston": "^1.0.0"
   },
   "main": "./lib/winston-graylog2",
   "scripts": {


### PR DESCRIPTION
Fixes a vulnerability warning raised from nsp (https://nodesecurity.io/)
fixes #25

* all tests still succeed
* did a quick local test, works properly afaics
* ran nsp after upgrading, no more warning

Please publish this asap to npm :)

