### PR TITLE
Truncate logged message to 100 chars and log as short message

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -82,7 +82,7 @@ util.inherits(Graylog2, winston.Transport);
 Graylog2.prototype.log = function(level, msg, meta, callback) {
   meta = prepareMeta(meta);
 
-  this.graylog2[getMessageLevel(level)](msg, meta);
+  this.graylog2[getMessageLevel(level)](msg.substring(0, 100), msg, meta);
   callback(null, true);
 };
 


### PR DESCRIPTION
Graylog2 supports a short message and full message.
Currently the winston-graylog2 does not take advantage of this feature.
This change truncate the normal message to 100 chars and uses that as the short_message argument.