### PR TITLE
Support static metadata, always to be used as additional context to a logged message

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -38,7 +38,7 @@ function getMessageLevel(winstonLevel) {
  * @param  {Object} meta
  * @return {Object}
  */
-function prepareMeta(meta) {
+function prepareMeta(meta, staticMeta) {
   meta = meta || {};
 
   if (meta instanceof Error) {
@@ -53,7 +53,7 @@ function prepareMeta(meta) {
     });
   }
 
-  meta = _.merge(meta, this.staticMeta);
+  meta = _.merge(meta, staticMeta);
 
   return meta;
 }
@@ -88,7 +88,7 @@ var Graylog2 = winston.transports.Graylog2 = function(options) {
 util.inherits(Graylog2, winston.Transport);
 
 Graylog2.prototype.log = function(level, msg, meta, callback) {
-  meta = prepareMeta.bind(this)(meta);
+  meta = prepareMeta(meta, this.staticMeta);
   msg  = this.prelog(msg);
 
   this.graylog2[getMessageLevel(level)](msg.substring(0, 100), msg, meta);

--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -76,9 +76,9 @@ var Graylog2 = winston.transports.Graylog2 = function(options) {
   this.silent = options.silent || false;
   this.handleExceptions = options.handleExceptions || false;
   this.prelog = (typeof options.prelog === 'function') ? options.prelog : prelog;
-  this.graylog2 = new graylog2.graylog(options.graylog);
-
   this.staticMeta = options.staticMeta || {};
+
+  this.graylog2 = new graylog2.graylog(options.graylog);
 
   this.graylog2.on('error', function(error) {
     console.error('Error while trying to write to graylog2:', error);

--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -53,6 +53,9 @@ function prepareMeta(meta) {
     });
   }
 
+  // merge the meta data with the statically configured metadata
+  meta = _.merge(meta, this.staticMeta);
+
   return meta;
 }
 
@@ -76,6 +79,8 @@ var Graylog2 = winston.transports.Graylog2 = function(options) {
   this.prelog = (typeof options.prelog === 'function') ? options.prelog : prelog;
   this.graylog2 = new graylog2.graylog(options.graylog);
 
+  this.staticMeta = options.staticMeta || {};
+
   this.graylog2.on('error', function(error) {
     console.error('Error while trying to write to graylog2:', error);
   });
@@ -84,7 +89,7 @@ var Graylog2 = winston.transports.Graylog2 = function(options) {
 util.inherits(Graylog2, winston.Transport);
 
 Graylog2.prototype.log = function(level, msg, meta, callback) {
-  meta = prepareMeta(meta);
+  meta = prepareMeta.bind(this)(meta);
   msg  = this.prelog(msg);
 
   this.graylog2[getMessageLevel(level)](msg.substring(0, 100), msg, meta);

--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -53,7 +53,6 @@ function prepareMeta(meta) {
     });
   }
 
-  // merge the meta data with the statically configured metadata
   meta = _.merge(meta, this.staticMeta);
 
   return meta;

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ var logger = new(winston.Logger)({
   - __hostname__: the name of this host (default: os.hostname())
   - __facility__: the facility for these log messages (default: "Node.js")
   - __bufferSize__: max UDP packet size, should never exceed the MTU of your system (default: 1400)
+  - __staticMeta__: meta data to be allways used by each logging message, for instance environment (development, staging, live)
 
 
 example:
@@ -59,7 +60,8 @@ example:
     servers: [{host: 'localhost', port: 12201}, {host: 'remote.host', port: 12201}],
     hostname: 'myServer',
     facility: 'myAwesomeApp',
-    bufferSize: 1400
+    bufferSize: 1400,
+    staticMeta: {env: 'staging'}
   }
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ var logger = new(winston.Logger)({
   - __hostname__: the name of this host (default: os.hostname())
   - __facility__: the facility for these log messages (default: "Node.js")
   - __bufferSize__: max UDP packet size, should never exceed the MTU of your system (default: 1400)
-  - __staticMeta__: meta data to be allways used by each logging message, for instance environment (development, staging, live)
+  - __staticMeta__: meta data to be always used by each logging message, for instance environment (development, staging, live)
 
 
 example:


### PR DESCRIPTION
Hi,

I want some context (for example, environmenttype, organisation, etc.) to be always logged as meta data. This makes it easier for us to filter messages, based on this context.

Could you review this change, and if acceptable, merge and release.

Cheers,

Lennard.