### PR TITLE
Avoid TypeError to read only property

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -64,12 +64,15 @@ function prelog(msg) {
 
 var Graylog2 = winston.transports.Graylog2 = function(options) {
   options = options || {};
-  options.graylog = options.graylog || {
-    servers: [{
-      'host': 'localhost',
-      port: 12201
-    }]
-  };
+  this.graylog = _.get(options, 'graylog');
+  if (!this.graylog) {
+    this.graylog = {
+      servers: [{
+        host: 'localhost',
+        port: 12201
+      }]
+    };
+  }
 
   this.name = options.name || 'graylog2';
   this.level = options.level || 'info';
@@ -78,7 +81,7 @@ var Graylog2 = winston.transports.Graylog2 = function(options) {
   this.prelog = (typeof options.prelog === 'function') ? options.prelog : prelog;
   this.staticMeta = options.staticMeta || {};
 
-  this.graylog2 = new graylog2.graylog(options.graylog);
+  this.graylog2 = new graylog2.graylog(this.graylog);
 
   this.graylog2.on('error', function(error) {
     console.error('Error while trying to write to graylog2:', error);

--- a/test/winston-graylog2-test.js
+++ b/test/winston-graylog2-test.js
@@ -14,6 +14,14 @@ describe('winstone-graylog2', function() {
       assert.ok(winstonGraylog2.level === 'info');
       assert.ok(winstonGraylog2.silent === false);
       assert.ok(winstonGraylog2.handleExceptions === false);
+      assert.deepEqual(
+        winstonGraylog2.graylog, {
+          servers: [{
+            host: 'localhost',
+            port: 12201
+          }]
+        }
+      );
     });
 
     it('should have a log function', function() {
@@ -70,5 +78,17 @@ describe('winstone-graylog2', function() {
       assert.ok(logger.transports.hasOwnProperty('graylog2'));
     });
 
+    it('should set graylog configuration', function () {
+      var graylogOptions = {
+        servers: [{
+          host: 'somehost',
+          port: 22222
+        }]
+      };
+      var winstonGraylog2 = new(WinstonGraylog2)({
+        graylog: graylogOptions
+      });
+      assert.deepEqual(winstonGraylog2.graylog, graylogOptions);
+    });
   });
 });


### PR DESCRIPTION
This PR fixes the problem that causes "TypeError: Cannot assign to read only property 'graylog' of #<Object>".

This behavior can be detected when **winston-graylog2** is used with a lib like [node-config](http://github.com/lorenwest/node-config) or with a not writable object.

This snippet can reproduce the error ->

```
const winston = require("winston");
const config = require("config");
winston.add(require('winston-graylog2'), config.get("graylog2"));
```

And the key in configuration ->

```
"graylog2": {
    "name": "Graylog",
    "level": "debug",
    "graylog": {
      "servers": [{
        "host": "localhost",
        "port": 6665
      }]
    }
  }
```