### PR TITLE
Expose meta property to the prelog method

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -58,7 +58,7 @@ function prepareMeta(meta, staticMeta) {
   return meta;
 }
 
-function prelog(msg) {
+function prelog(msg, meta) {
   return msg;
 }
 
@@ -89,7 +89,7 @@ util.inherits(Graylog2, winston.Transport);
 
 Graylog2.prototype.log = function(level, msg, meta, callback) {
   meta = prepareMeta(meta, this.staticMeta);
-  msg  = this.prelog(msg);
+  msg  = this.prelog(msg, meta);
 
   this.graylog2[getMessageLevel(level)](msg.substring(0, 100), msg, meta);
   callback(null, true);


### PR DESCRIPTION
We had a situation where the message data was being sent through empty, but meta was populated. We needed to use the `prelog` method to extract data from the `meta` property to build a new message.