### PR TITLE
Added an ability to post-process metadata.

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -62,6 +62,10 @@ function prelog(msg) {
   return msg;
 }
 
+function processMeta(meta){
+  return meta;
+}
+
 var Graylog2 = winston.transports.Graylog2 = function(options) {
   options = options || {};
   this.graylog = _.get(options, 'graylog');
@@ -79,6 +83,7 @@ var Graylog2 = winston.transports.Graylog2 = function(options) {
   this.silent = options.silent || false;
   this.handleExceptions = options.handleExceptions || false;
   this.prelog = (typeof options.prelog === 'function') ? options.prelog : prelog;
+  this.processMeta = (typeof options.processMeta === 'function') ? options.processMeta : processMeta;
   this.staticMeta = options.staticMeta || {};
 
   this.graylog2 = new graylog2.graylog(this.graylog);
@@ -91,7 +96,7 @@ var Graylog2 = winston.transports.Graylog2 = function(options) {
 util.inherits(Graylog2, winston.Transport);
 
 Graylog2.prototype.log = function(level, msg, meta, callback) {
-  meta = prepareMeta(meta, this.staticMeta);
+  meta = this.processMeta(prepareMeta(meta, this.staticMeta));
   msg  = this.prelog(msg);
 
   this.graylog2[getMessageLevel(level)](msg.substring(0, 100), msg, meta);

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     },
     {
       "name": "Arttu Tervo"
+    },
+    {
+      "name": "Ivan Batic"
     }
   ],
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ var logger = new(winston.Logger)({
 * __silent__: Boolean flag indicating whether to suppress output. (default: false)
 * __handleExceptions__: Boolean flag, whenever to handle uncaught exceptions. (default: false)
 * __prelog__: Pre-filtering function, to clean message before sending to graylog2 (default: empty function)
+* __processMeta__: Metadata post-filtering function, to clean the metadata (stack traces, process info) before sending them to graylog2 (default: empty function)
 * __graylog__:
   - __servers__; list of graylog2 servers
     * __host__: your server address (default: localhost)

--- a/test/winston-graylog2-test.js
+++ b/test/winston-graylog2-test.js
@@ -90,5 +90,27 @@ describe('winstone-graylog2', function() {
       });
       assert.deepEqual(winstonGraylog2.graylog, graylogOptions);
     });
+
+    it('should have a processMeta function', function(){
+      var winstonGraylog2 = new(WinstonGraylog2)();
+      assert.ok(typeof winstonGraylog2.processMeta === 'function');
+    });
+
+    it('should be able to set the processMeta function', function(){
+      var extension = {foo: 'bar'};
+      var winstonGraylog2 = new (WinstonGraylog2)({
+        processMeta: function(meta){
+            meta.testAttribute = extension;
+            delete meta.baz;
+            return meta;
+        }
+      });
+      winstonGraylog2.graylog2.info = function(msg, _, meta){
+        assert.equal(extension, meta.testAttribute);
+        assert.equal(undefined, meta.baz);
+      };
+
+      winstonGraylog2.log('info', 'alog', {baz: 'boo'}, function(){});
+    });
   });
 });


### PR DESCRIPTION
When sending in data from remote client machines, it is useful to be able to anonymise user data, like remove FS paths from stack traces and so on. 
This PR adds a __processMeta__ function that gets the metadata that's to be sent to the Graylog server and can update it accordingly.