### PR TITLE
Fix Winston Transport properties that were not being set

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -63,6 +63,8 @@ function prelog(msg) {
 }
 
 var Graylog2 = winston.transports.Graylog2 = function(options) {
+  winston.Transport.call(this, options);
+
   options = options || {};
   this.graylog = _.get(options, 'graylog');
   if (!this.graylog) {

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ var logger = new(winston.Logger)({
 * __level__: Level of messages this transport should log. (default: info)
 * __silent__: Boolean flag indicating whether to suppress output. (default: false)
 * __handleExceptions__: Boolean flag, whenever to handle uncaught exceptions. (default: false)
+* __exceptionsLevel__: Level of exceptions logs when handleExceptions is true. (default: error)
 * __prelog__: Pre-filtering function, to clean message before sending to graylog2 (default: empty function)
 * __graylog__:
   - __servers__; list of graylog2 servers

--- a/test/winston-graylog2-test.js
+++ b/test/winston-graylog2-test.js
@@ -7,7 +7,7 @@ var WinstonGraylog2 = require('../lib/winston-graylog2.js');
 describe('winstone-graylog2', function() {
   describe('Creating the trasport', function() {
 
-    it('Have default properties when instantiated', function() {
+    it('should have default properties when instantiated', function() {
       var winstonGraylog2 = new(WinstonGraylog2)();
 
       assert.ok(winstonGraylog2.name === 'graylog2');
@@ -22,6 +22,35 @@ describe('winstone-graylog2', function() {
           }]
         }
       );
+    });
+
+    it('should allow properties to be set when instantiated', function() {
+      var options = {
+        name: 'not-default',
+        level: 'not-default',
+        graylog: {
+          servers: [{
+            host: '127.0.0.1',
+            port: 12202
+          }]
+        }
+      };
+      var winstonGraylog2 = new(WinstonGraylog2)(options);
+
+      assert.ok(winstonGraylog2.name === options.name);
+      assert.ok(winstonGraylog2.level === options.level);
+      assert.deepEqual(winstonGraylog2.graylog, options.graylog);
+    });
+
+    it('should allow Winston properties to be set when instantiated', function() {
+      var options = {
+        handleExceptions: true,
+        exceptionsLevel: 'not-default'
+      };
+      var winstonGraylog2 = new(WinstonGraylog2)(options);
+
+      assert.ok(winstonGraylog2.handleExceptions === options.handleExceptions);
+      assert.ok(winstonGraylog2.exceptionsLevel === options.exceptionsLevel);
     });
 
     it('should have a log function', function() {


### PR DESCRIPTION
winston.Transport was not being called.  This caused properties such as
exceptionsLevel to not have a default value or be able to be set as an
option.

Tests were added to make sure both winston-graylog2 specific properties
and Winston properties can be set through options.