### PR TITLE
Map default winston log level 'warn' to graylog2 'warning' log level 

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -18,6 +18,7 @@ function getMessageLevel(winstonLevel) {
     crit: 'critical',
     error: 'error',
     warning: 'warning',
+    warn: 'warning',
     notice: 'notice',
     info: 'info',
     debug: 'debug'

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ alert          | alert
 crit           | critical
 error          | error
 warning        | warning
+warn           | warning
 notice         | notice
 info           | info
 debug          | debug


### PR DESCRIPTION
Hi,

The default loglevel 'warn' was mapped to 'info'.
I added the mapping from 'warn' to 'warning'.

Could you review and merge if ok?

Thanks,

Lennard.