### PR TITLE
Update lodash to 3.7, since we depend on _.get.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "graylog2": "^0.1.3",
-    "lodash": "^3.1.0",
+    "lodash": "^3.7.0",
     "winston": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi, I just ran into this lodash versioning issue.

`_.get` is used [in the library](https://github.com/namshi/winston-graylog2/blob/master/lib/winston-graylog2.js#L70), but that method is [only available from lodash v3.7 and higher](https://github.com/lodash/lodash/wiki/Changelog#v370).

Explicitly adding lodash as a dependency at v3.7 or higher resolves the issue, but probably better to solve it upstream!