### PR TITLE
Fix default level issue.

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -6,12 +6,12 @@ var graylog2 = require('graylog2');
 var _ = require('lodash');
 
 /**
- * Remaping winston level on greylog
+ * Remapping winston level on graylog
  *
  * @param  {String} winstonLevel
  * @return {String}
  */
-function getMessageLevel(winstonLevel) {
+var getMessageLevel = (function() {
   var levels = {
     emerg: 'emergency',
     alert: 'alert',
@@ -23,10 +23,10 @@ function getMessageLevel(winstonLevel) {
     info: 'info',
     debug: 'debug'
   };
-
-  return levels[winstonLevel] || levels.info;
-}
-
+  return function(winstonLevel) {
+    return levels[winstonLevel] || levels.info;
+  }
+})();
 
 /**
  * Preparing metadata for graylog
@@ -78,7 +78,6 @@ var Graylog2 = winston.transports.Graylog2 = function(options) {
   }
 
   this.name = options.name || 'graylog2';
-  this.level = options.level || 'info';
   this.silent = options.silent || false;
   this.handleExceptions = options.handleExceptions || false;
   this.prelog = (typeof options.prelog === 'function') ? options.prelog : prelog;

--- a/test/winston-graylog2-test.js
+++ b/test/winston-graylog2-test.js
@@ -11,7 +11,7 @@ describe('winstone-graylog2', function() {
       var winstonGraylog2 = new(WinstonGraylog2)();
 
       assert.ok(winstonGraylog2.name === 'graylog2');
-      assert.ok(winstonGraylog2.level === 'info');
+      assert.ok(winstonGraylog2.level === undefined);
       assert.ok(winstonGraylog2.silent === false);
       assert.ok(winstonGraylog2.handleExceptions === false);
       assert.deepEqual(


### PR DESCRIPTION
According to https://github.com/winstonjs/winston/blob/master/lib/winston/transports/transport.js#L32, 
default level should not be set for winston transport; otherwise the graylog2 transport will always override the output level filter setting for any winston logger using it (https://github.com/winstonjs/winston/blob/master/lib/winston/logger.js#L154). Unless you delete the level setting after it's initialized, e.g. `delete graylog2Transport.level;`.