### PR TITLE
Close Graylog2 connection on close. Fixes #24

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -97,4 +97,8 @@ Graylog2.prototype.log = function(level, msg, meta, callback) {
   callback(null, true);
 };
 
+Graylog2.prototype.close = function() {
+  this.graylog2.close();
+};
+
 module.exports = Graylog2;


### PR DESCRIPTION
Fix an issue where the Graylog2 transport ignores requests
from Winston to close the transport. This causes applications
depending on Winston's close() functionality to hang.

Winston has a feature where transports can support the `.close()`
call, which is called when a program calls `.close()` on the
Winston logger instance. Transports can use this method to
release their resources and shut down gracefully.

This pull request uses this feature to close the Graylog2 connection
when Winston is cleaning up.

Caveat: currently there is no way to pass Graylog2's close()
callback to Winston, since Winston does not support this.