### PR TITLE
Add eslint and prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,38 @@
+{
+  "extends": "google",
+  "plugins": ["prettier"],
+  "env": {
+    "node": true,
+    "es6": true
+  },
+  "rules": {
+    "quote-props": ["error", "as-needed"],
+    "quotes": ["error", "single", { "avoidEscape": true }],
+    "max-len": [
+      "error",
+      {
+        "code": 80,
+        "ignoreTemplateLiterals": true,
+        "ignoreTrailingComments": true,
+        "ignoreComments": true,
+        "ignoreRegExpLiterals": true
+      }
+    ],
+    "prettier/prettier": [
+      "error",
+      {
+        "singleQuote": true,
+        "trailingComma": "es5",
+        "bracketSpacing": false,
+        "arrowParens": "always"
+      }
+    ]
+  },
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
+    }
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,7 @@
     "max-len": [
       "error",
       {
-        "code": 80,
+        "code": 100, // TODO: set back to 80 after all lines can fit
         "ignoreTemplateLiterals": true,
         "ignoreTrailingComments": true,
         "ignoreComments": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
   },
   "rules": {
     "quote-props": ["error", "as-needed"],
+    "new-cap": ["error", {"properties": false}], // TODO: remove once newcap errors are fixed.
     "quotes": ["error", "single", { "avoidEscape": true }],
     "max-len": [
       "error",

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: node_js
+
 sudo: false
+
 node_js:
    - 6.10
+  
+install:
+  - npm install --dev
 
+script:
+  - yarn lint
+  - yarn test

--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var util = require('util');
-var winston = require('winston');
-var graylog2 = require('graylog2');
-var _ = require('lodash');
+const util = require('util');
+const winston = require('winston');
+const graylog2 = require('graylog2');
+const _ = require('lodash');
 
 /**
  * Remapping winston level on graylog

--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -80,7 +80,7 @@ var Graylog2 = winston.transports.Graylog2 = function(options) {
   this.processMeta = (typeof options.processMeta === 'function') ? options.processMeta : _.identity;
   this.staticMeta = options.staticMeta || {};
 
-  this.graylog2 = new graylog2.graylog(this.graylog);
+  this.graylog2 = new graylog2.graylog(this.graylog); // TODO: Fix in relation to https://eslint.org/docs/rules/new-cap
 
   this.graylog2.on('error', function(error) {
     console.error('Error while trying to write to graylog2:', error);

--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -11,8 +11,8 @@ const _ = require('lodash');
  * @param  {String} winstonLevel
  * @return {String}
  */
-var getMessageLevel = (function() {
-  var levels = {
+let getMessageLevel = (function() {
+  let levels = {
     emerg: 'emergency',
     alert: 'alert',
     crit: 'critical',
@@ -21,11 +21,11 @@ var getMessageLevel = (function() {
     warn: 'warning',
     notice: 'notice',
     info: 'info',
-    debug: 'debug'
+    debug: 'debug',
   };
   return function(winstonLevel) {
     return levels[winstonLevel] || levels.info;
-  }
+  };
 })();
 
 /**
@@ -37,6 +37,7 @@ var getMessageLevel = (function() {
  * Here we remap metadata to handle this kind of situation
  *
  * @param  {Object} meta
+ * @param  {Object} staticMeta
  * @return {Object}
  */
 function prepareMeta(meta, staticMeta) {
@@ -59,25 +60,31 @@ function prepareMeta(meta, staticMeta) {
   return meta;
 }
 
-var Graylog2 = winston.transports.Graylog2 = function(options) {
+let Graylog2 = (winston.transports.Graylog2 = function(options) {
   winston.Transport.call(this, options);
 
   options = options || {};
   this.graylog = _.get(options, 'graylog');
   if (!this.graylog) {
     this.graylog = {
-      servers: [{
-        host: 'localhost',
-        port: 12201
-      }]
+      servers: [
+        {
+          host: 'localhost',
+          port: 12201,
+        },
+      ],
     };
   }
 
   this.name = options.name || 'graylog2';
   this.silent = options.silent || false;
   this.handleExceptions = options.handleExceptions || false;
-  this.prelog = (typeof options.prelog === 'function') ? options.prelog : _.identity;
-  this.processMeta = (typeof options.processMeta === 'function') ? options.processMeta : _.identity;
+  this.prelog =
+    typeof options.prelog === 'function' ? options.prelog : _.identity;
+  this.processMeta =
+    typeof options.processMeta === 'function'
+      ? options.processMeta
+      : _.identity;
   this.staticMeta = options.staticMeta || {};
 
   this.graylog2 = new graylog2.graylog(this.graylog); // TODO: Fix in relation to https://eslint.org/docs/rules/new-cap
@@ -85,13 +92,13 @@ var Graylog2 = winston.transports.Graylog2 = function(options) {
   this.graylog2.on('error', function(error) {
     console.error('Error while trying to write to graylog2:', error);
   });
-};
+});
 
 util.inherits(Graylog2, winston.Transport);
 
 Graylog2.prototype.log = function(level, msg, meta, callback) {
   meta = this.processMeta(prepareMeta(meta, this.staticMeta));
-  msg  = this.prelog(msg);
+  msg = this.prelog(msg);
 
   this.graylog2[getMessageLevel(level)](msg.substring(0, 100), msg, meta);
   callback(null, true);

--- a/package.json
+++ b/package.json
@@ -44,7 +44,11 @@
     "winston": "^2.4.0"
   },
   "devDependencies": {
-    "mocha": "*"
+    "eslint": "^4.19.1",
+    "eslint-config-google": "^0.9.1",
+    "eslint-plugin-prettier": "^2.6.0",
+    "mocha": "*",
+    "prettier": "^1.11.1"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "url": "http://github.com/flite/winston-graylog2.git"
   },
   "scripts": {
-    "test": "mocha -b"
+    "test": "mocha -b",
+    "lint": "eslint lib/ test/"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-# winston-graylog2 [![Build Status](https://secure.travis-ci.org/flite/winston-graylog2.png)](http://travis-ci.org/flite/winston-graylog2)
+[![Build Status](https://secure.travis-ci.org/namshi/winston-graylog2.png)](http://travis-ci.org/namshi/winston-graylog2)
+
+# winston-graylog2 
 
 > LOOKING FOR A MAINTAINER!
 >

--- a/test/winston-graylog2-test.js
+++ b/test/winston-graylog2-test.js
@@ -6,36 +6,37 @@ const WinstonGraylog2 = require('../lib/winston-graylog2.js');
 
 describe('winstone-graylog2', function() {
   describe('Creating the trasport', function() {
-
     it('should have default properties when instantiated', function() {
-      var winstonGraylog2 = new(WinstonGraylog2)();
+      let winstonGraylog2 = new WinstonGraylog2();
 
       assert.ok(winstonGraylog2.name === 'graylog2');
       assert.ok(winstonGraylog2.level === undefined);
       assert.ok(winstonGraylog2.silent === false);
       assert.ok(winstonGraylog2.handleExceptions === false);
-      assert.deepEqual(
-        winstonGraylog2.graylog, {
-          servers: [{
+      assert.deepEqual(winstonGraylog2.graylog, {
+        servers: [
+          {
             host: 'localhost',
-            port: 12201
-          }]
-        }
-      );
+            port: 12201,
+          },
+        ],
+      });
     });
 
     it('should allow properties to be set when instantiated', function() {
-      var options = {
+      let options = {
         name: 'not-default',
         level: 'not-default',
         graylog: {
-          servers: [{
-            host: '127.0.0.1',
-            port: 12202
-          }]
-        }
+          servers: [
+            {
+              host: '127.0.0.1',
+              port: 12202,
+            },
+          ],
+        },
       };
-      var winstonGraylog2 = new(WinstonGraylog2)(options);
+      let winstonGraylog2 = new WinstonGraylog2(options);
 
       assert.ok(winstonGraylog2.name === options.name);
       assert.ok(winstonGraylog2.level === options.level);
@@ -43,63 +44,63 @@ describe('winstone-graylog2', function() {
     });
 
     it('should allow Winston properties to be set when instantiated', function() {
-      var options = {
+      let options = {
         handleExceptions: true,
-        exceptionsLevel: 'not-default'
+        exceptionsLevel: 'not-default',
       };
-      var winstonGraylog2 = new(WinstonGraylog2)(options);
+      let winstonGraylog2 = new WinstonGraylog2(options);
 
       assert.ok(winstonGraylog2.handleExceptions === options.handleExceptions);
       assert.ok(winstonGraylog2.exceptionsLevel === options.exceptionsLevel);
     });
 
     it('should have a log function', function() {
-      var winstonGraylog2 = new(WinstonGraylog2)();
+      let winstonGraylog2 = new WinstonGraylog2();
       assert.ok(typeof winstonGraylog2.log === 'function');
     });
 
     it('should have prelog function', function() {
-      var winstonGraylog2 = new(WinstonGraylog2)();
+      let winstonGraylog2 = new WinstonGraylog2();
       assert.ok(typeof winstonGraylog2.prelog === 'function');
     });
 
     it('should have filter by prelog function', function(done) {
-      var msg = 'test';
-      var winstonGraylog2 = new(WinstonGraylog2)();
+      let msg = 'test';
+      let winstonGraylog2 = new WinstonGraylog2();
       winstonGraylog2.graylog2.info = function(data) {
         assert.ok(msg === data);
         done();
       };
-      winstonGraylog2.log('info', msg, {}, function(){});
+      winstonGraylog2.log('info', msg, {}, function() {});
     });
 
     it('should be able to set prelog function', function(done) {
-      var msg = '  test  ';
-      var winstonGraylog2 = new(WinstonGraylog2)({
+      let msg = '  test  ';
+      let winstonGraylog2 = new WinstonGraylog2({
         prelog: function(msg) {
           return msg.trim();
-        }
+        },
       });
       winstonGraylog2.graylog2.info = function(data) {
         assert.ok(data === 'test');
         done();
       };
-      winstonGraylog2.log('info', msg, {}, function(){});
+      winstonGraylog2.log('info', msg, {}, function() {});
     });
 
     it('can be registered as winston transport', function() {
-      var logger = new(winston.Logger)({
+      let logger = new winston.Logger({
         exitOnError: false,
-        transports: [new(WinstonGraylog2)()]
+        transports: [new WinstonGraylog2()],
       });
 
       assert.ok(logger.transports.hasOwnProperty('graylog2'));
     });
 
     it('can be registered as winston transport using the add() function', function() {
-      var logger = new(winston.Logger)({
+      let logger = new winston.Logger({
         exitOnError: false,
-        transports: []
+        transports: [],
       });
 
       logger.add(WinstonGraylog2);
@@ -107,39 +108,41 @@ describe('winstone-graylog2', function() {
       assert.ok(logger.transports.hasOwnProperty('graylog2'));
     });
 
-    it('should set graylog configuration', function () {
-      var graylogOptions = {
-        servers: [{
-          host: 'somehost',
-          port: 22222
-        }]
+    it('should set graylog configuration', function() {
+      let graylogOptions = {
+        servers: [
+          {
+            host: 'somehost',
+            port: 22222,
+          },
+        ],
       };
-      var winstonGraylog2 = new(WinstonGraylog2)({
-        graylog: graylogOptions
+      let winstonGraylog2 = new WinstonGraylog2({
+        graylog: graylogOptions,
       });
       assert.deepEqual(winstonGraylog2.graylog, graylogOptions);
     });
 
-    it('should have a processMeta function', function(){
-      var winstonGraylog2 = new(WinstonGraylog2)();
+    it('should have a processMeta function', function() {
+      let winstonGraylog2 = new WinstonGraylog2();
       assert.ok(typeof winstonGraylog2.processMeta === 'function');
     });
 
-    it('should be able to set the processMeta function', function(){
-      var extension = {foo: 'bar'};
-      var winstonGraylog2 = new (WinstonGraylog2)({
-        processMeta: function(meta){
-            meta.testAttribute = extension;
-            delete meta.baz;
-            return meta;
-        }
+    it('should be able to set the processMeta function', function() {
+      let extension = {foo: 'bar'};
+      let winstonGraylog2 = new WinstonGraylog2({
+        processMeta: function(meta) {
+          meta.testAttribute = extension;
+          delete meta.baz;
+          return meta;
+        },
       });
-      winstonGraylog2.graylog2.info = function(msg, _, meta){
+      winstonGraylog2.graylog2.info = function(msg, _, meta) {
         assert.equal(extension, meta.testAttribute);
         assert.equal(undefined, meta.baz);
       };
 
-      winstonGraylog2.log('info', 'alog', {baz: 'boo'}, function(){});
+      winstonGraylog2.log('info', 'alog', {baz: 'boo'}, function() {});
     });
   });
 });

--- a/test/winston-graylog2-test.js
+++ b/test/winston-graylog2-test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var assert = require('assert');
-var winston = require('winston');
-var WinstonGraylog2 = require('../lib/winston-graylog2.js');
+const assert = require('assert');
+const winston = require('winston');
+const WinstonGraylog2 = require('../lib/winston-graylog2.js');
 
 describe('winstone-graylog2', function() {
   describe('Creating the trasport', function() {


### PR DESCRIPTION
Standardize code by adding a prettifier and linter. In this case eslint and prettier.
eslint google config and prettier as an eslint plugin for minimal conflict between rules.

Fixes #53 