### PR TITLE
Fix incorrect Error objects when logging and Added  formatters

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -2,6 +2,7 @@
 
 const util = require('util');
 const winston = require('winston');
+const common = require('winston/lib/winston/common');
 const graylog2 = require('graylog2');
 const _ = require('lodash');
 
@@ -79,12 +80,22 @@ let Graylog2 = (winston.transports.Graylog2 = function(options) {
   this.name = options.name || 'graylog2';
   this.silent = options.silent || false;
   this.handleExceptions = options.handleExceptions || false;
-  this.prelog =
-    typeof options.prelog === 'function' ? options.prelog : _.identity;
+  this.json = options.json || false;
+  this.colorize = options.colorize || false;
+  this.label = options.label || null;
+  this.prettyPrint = options.prettyPrint || false;
+  this.timestamp = options.timestamp || true;
+  this.logstash = options.logstash || null;
+  this.depth = options.depth || null;
+  this.showLevel = options.showLevel === undefined ? true : options.showLevel;
+  if (this.json) {
+    this.stringify = options.stringify;
+  }
   this.processMeta =
     typeof options.processMeta === 'function'
       ? options.processMeta
       : _.identity;
+
   this.staticMeta = options.staticMeta || {};
 
   this.graylog2 = new graylog2.graylog(this.graylog); // TODO: Fix in relation to https://eslint.org/docs/rules/new-cap
@@ -97,8 +108,24 @@ let Graylog2 = (winston.transports.Graylog2 = function(options) {
 util.inherits(Graylog2, winston.Transport);
 
 Graylog2.prototype.log = function(level, msg, meta, callback) {
+    msg = common.log({
+        level: level,
+        message: msg,
+        meta: meta,
+        json: this.json,
+        raw: this.raw,
+        timestamp: this.timestamp,
+        logstash: this.logstash,
+        colorize: this.colorize,
+        prettyPrint: this.prettyPrint,
+        label: this.label,
+        showLevel: this.showLevel,
+        depth: this.depth,
+        stringify: this.stringify,
+        formatter: this.formatter,
+        humanReadableUnhandledException: this.humanReadableUnhandledException
+    })
   meta = this.processMeta(prepareMeta(meta, this.staticMeta));
-  msg = this.prelog(msg);
 
   this.graylog2[getMessageLevel(level)](msg.substring(0, 100), msg, meta);
   callback(null, true);

--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -81,12 +81,9 @@ let Graylog2 = (winston.transports.Graylog2 = function(options) {
   this.silent = options.silent || false;
   this.handleExceptions = options.handleExceptions || false;
   this.json = options.json || false;
-  this.colorize = options.colorize || false;
   this.label = options.label || null;
-  this.prettyPrint = options.prettyPrint || false;
   this.timestamp = options.timestamp || true;
   this.logstash = options.logstash || null;
-  this.depth = options.depth || null;
   this.showLevel = options.showLevel === undefined ? true : options.showLevel;
   if (this.json) {
     this.stringify = options.stringify;
@@ -116,11 +113,8 @@ Graylog2.prototype.log = function(level, msg, meta, callback) {
     raw: this.raw,
     timestamp: this.timestamp,
     logstash: this.logstash,
-    colorize: this.colorize,
-    prettyPrint: this.prettyPrint,
     label: this.label,
     showLevel: this.showLevel,
-    depth: this.depth,
     stringify: this.stringify,
     formatter: this.formatter,
     humanReadableUnhandledException: this.humanReadableUnhandledException,

--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -108,23 +108,23 @@ let Graylog2 = (winston.transports.Graylog2 = function(options) {
 util.inherits(Graylog2, winston.Transport);
 
 Graylog2.prototype.log = function(level, msg, meta, callback) {
-    msg = common.log({
-        level: level,
-        message: msg,
-        meta: meta,
-        json: this.json,
-        raw: this.raw,
-        timestamp: this.timestamp,
-        logstash: this.logstash,
-        colorize: this.colorize,
-        prettyPrint: this.prettyPrint,
-        label: this.label,
-        showLevel: this.showLevel,
-        depth: this.depth,
-        stringify: this.stringify,
-        formatter: this.formatter,
-        humanReadableUnhandledException: this.humanReadableUnhandledException
-    })
+  msg = common.log({
+    level: level,
+    message: msg,
+    meta: meta,
+    json: this.json,
+    raw: this.raw,
+    timestamp: this.timestamp,
+    logstash: this.logstash,
+    colorize: this.colorize,
+    prettyPrint: this.prettyPrint,
+    label: this.label,
+    showLevel: this.showLevel,
+    depth: this.depth,
+    stringify: this.stringify,
+    formatter: this.formatter,
+    humanReadableUnhandledException: this.humanReadableUnhandledException,
+  });
   meta = this.processMeta(prepareMeta(meta, this.staticMeta));
 
   this.graylog2[getMessageLevel(level)](msg.substring(0, 100), msg, meta);

--- a/test/winston-graylog2-test.js
+++ b/test/winston-graylog2-test.js
@@ -59,26 +59,26 @@ describe('winstone-graylog2', function() {
       assert.ok(typeof winstonGraylog2.log === 'function');
     });
 
-    it('should have prelog function', function() {
+    it('should have formatter function', function() {
       let winstonGraylog2 = new WinstonGraylog2();
-      assert.ok(typeof winstonGraylog2.prelog === 'function');
+      assert.ok(typeof winstonGraylog2.formatter === 'undefined');
     });
 
-    it('should have filter by prelog function', function(done) {
+    it('should have filter by formatter function', function(done) {
       let msg = 'test';
       let winstonGraylog2 = new WinstonGraylog2();
       winstonGraylog2.graylog2.info = function(data) {
-        assert.ok(msg === data);
+        assert.ok(data.indexOf(msg) !== -1);
         done();
       };
       winstonGraylog2.log('info', msg, {}, function() {});
     });
 
-    it('should be able to set prelog function', function(done) {
+    it('should be able to set formatter function', function(done) {
       let msg = '  test  ';
       let winstonGraylog2 = new WinstonGraylog2({
-        prelog: function(msg) {
-          return msg.trim();
+        formatter: function(args) {
+          return args.message.trim();
         },
       });
       winstonGraylog2.graylog2.info = function(data) {


### PR DESCRIPTION
**Bugfix**: Resolved issue related to incorrect error object when logging to graylog server.
      **Example** : - log.error(new Error('Error message')) prints empty message to graylog server as
prelog method receive empty string as message . So, to include correct error message and error stack in user-defined log message, prelog function is now called with error message and meta object including error stack and other properties.
**winston** version used: **2.4.4**

**Feature**: Replaced prelog option with formatter option as it automatically supports various formatters like json, raw etc and various styling by reusing winston's log method.






