### PR TITLE
Remove unnecessary runtime dependency: @types/winston

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     }
   ],
   "dependencies": {
-    "@types/winston": "^2.3.9",
     "graylog2": "^0.2.1",
     "lodash": "^4.17.5",
     "winston": "^2.4.0"


### PR DESCRIPTION
Since it's only needed to compile ts projects, but not needed to run js code that uses this transport.
My bad: forgot to remove it in the previous pull request.