### PR TITLE
Add precommit hook: run tests and lint code on each commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "eslint": "^4.19.1",
     "eslint-config-google": "^0.9.1",
     "eslint-plugin-prettier": "^2.6.0",
+    "husky": "^0.14.3",
+    "lint-staged": "^7.2.2",
     "mocha": "*",
     "prettier": "^1.11.1"
   },
@@ -70,6 +72,13 @@
   },
   "scripts": {
     "test": "mocha -b",
-    "lint": "eslint lib/ test/"
+    "lint": "eslint lib/ test/",
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.js": [
+      "npm run lint",
+      "npm run test"
+    ]
   }
 }


### PR DESCRIPTION
That way code (both tests and linting) will be checked locally on each commit. So, if you break anything, you'll immediately know. Since failing precommit hook will abort a commit. For example:

```
$ git commit
husky > npm run -s precommit (node v8.9.4)

 ❯ Running tasks for *.js
   ✖ npm run lint
     npm run test
✖ "npm run lint" found some errors. Please fix them and try committing again.
  
/home/schfkt/Documents/code/winston-graylog2/lib/winston-graylog2.js
16:5  error  Replace `'emerg'` with `emerg`               prettier/prettier
16:5  error  Unnecessarily quoted property 'emerg' found  quote-props

✖ 2 problems (2 errors, 0 warnings)
  2 errors, 0 warnings potentially fixable with the `--fix` option.


husky > pre-commit hook failed (add --no-verify to bypass)
```

```
$ git commit
husky > npm run -s precommit (node v8.9.4)

 ❯ Running tasks for *.js
   ✔ npm run lint
   ✖ npm run test
✖ "npm run test" found some errors. Please fix them and try committing again.


  winstone-graylog2
    Creating the trasport
  1) should have default properties when instantiated

  0 passing (5ms)
  1 failing

  1) winstone-graylog2
   Creating the trasport
     should have default properties when instantiated:

  AssertionError [ERR_ASSERTION]: false == true
  + expected - actual

  -false
  +true
  
  at Context.<anonymous> (test/winston-graylog2-test.js:12:14)


husky > pre-commit hook failed (add --no-verify to bypass)
```