### PR TITLE
Handle null messages from winston

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -71,10 +71,12 @@ class Graylog2 extends Transport {
   log(info, callback) {
     const {message, level, metadata} = info;
     const meta = Object.assign({}, metadata, this.staticMeta);
+    const cleanedMessage = message || '';
+    const shortMessage = cleanedMessage.substring(0, 100);
 
     // prettier-ignore
     setImmediate(() => {
-      this.graylog2Client[getMessageLevel(level)](message.substring(0, 100), message, meta);
+      this.graylog2Client[getMessageLevel(level)](shortMessage, cleanedMessage, meta);
     });
     callback();
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
       "name": "Pavel Ivanov",
       "email": "ivpavig@gmail.com",
       "url": "https://schfkt.github.io/"
+    },
+    {
+      "name": "potatopankakes"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
Winston will pass `null` for the message if that was supplied, and other transports (notably, `Console`, and `File`) support receiving `null` for the message.

The lower layer, `graylog2`, does not support receiving a `null` for the message, and so we need to pass along an empty string to keep from causing a runtime exception.