### PR TITLE
fix: metadata is pojo now

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -2,6 +2,7 @@
 
 const Transport = require('winston-transport');
 const {graylog: Graylog2Client} = require('graylog2');
+const _ = require('lodash');
 
 /**
  * Remapping winston level on graylog
@@ -63,6 +64,36 @@ class Graylog2 extends Transport {
   }
 
   /**
+   * Preparing metadata for graylog
+   * If we send a javascript `Error` object
+   * to gray log we'll end up with the
+   * `[object Object]` string.
+   * To have our infos we need to get the stack out of the error.
+   * Here we remap metadata to handle this kind of situation
+   *
+   * @param  {Object} meta
+   * @param  {Object} staticMeta
+   * @return {Object}
+   */
+  prepareMeta(meta, staticMeta) {
+    meta = meta || {};
+
+    if (meta instanceof Error) {
+      meta = {error: meta.stack};
+    } else if (typeof meta === 'object') {
+      meta = _.mapValues(meta, function(value) {
+        if (value instanceof Error) {
+          return value.stack;
+        }
+        return value;
+      });
+    }
+
+    meta = _.merge(meta, staticMeta);
+    return meta;
+  }
+
+  /**
    * Log a message to Graylog2.
    *
    * @param {Object} info - An object containing the `message` and `info`.
@@ -70,7 +101,7 @@ class Graylog2 extends Transport {
    */
   log(info, callback) {
     const {message, level, metadata} = info;
-    const meta = Object.assign({}, metadata, this.staticMeta);
+    const meta = this.prepareMeta(metadata, this.staticMeta);
     const cleanedMessage = message || '';
     const shortMessage = cleanedMessage.substring(0, 100);
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   ],
   "dependencies": {
     "graylog2": "^0.2.1",
+    "lodash": "^4.17.11",
     "winston": "^3.2.0",
     "winston-transport": "^4.3.0"
   },


### PR DESCRIPTION
After recent update to winston3, winston-graylog2 started sending `[object Object]` string in metadata.

This PR helps to resolve that error by extracting the values out of the Javascript object and then merging it with staticMeta.