### PR TITLE
Fix typescript type definitions: import for TransportStream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: node_js
 sudo: false
 
 node_js:
-   - 6.4.0
-  
+   - 10.21.0
+
 install:
   - npm install
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import * as TransportStream from "winston-transport";
+import TransportStream = require('winston-transport');
 
 declare class Graylog2Transport extends TransportStream {
   constructor(options?: Graylog2Transport.TransportOptions);

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "prettier": "^1.16.1"
   },
   "engines": {
-    "node": ">= 6.4.0"
+    "node": ">= 10.0.0"
   },
   "keywords": [
     "logging",


### PR DESCRIPTION
Make it work for both cases: when esModuleInterop is enabled or disabled.
Thanks @scalder27 for the suggestion.