### PR TITLE
fix(TypeScript): TransportStream import fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import * as TransportStream from "winston-transport";
+import TransportStream = require("winston-transport");
 
 declare class Graylog2Transport extends TransportStream {
   constructor(options?: Graylog2Transport.TransportOptions);


### PR DESCRIPTION
Hi.  It seems that the import for `TransportStream` is imported incorrectly.  When trying to implement a transport you get the following error:

>Type 'typeof TransportStream' is not a constructor function type.ts(2507)

So you are unable to

```
...
  transports: [
    new WinstonGraylog2(options),
...
```
Thank you.