### PR TITLE
Send error stack to Graylog

### DIFF
--- a/lib/winston-graylog2.js
+++ b/lib/winston-graylog2.js
@@ -76,7 +76,7 @@ class Graylog2 extends Transport {
 
     // prettier-ignore
     setImmediate(() => {
-      this.graylog2Client[getMessageLevel(level)](shortMessage, cleanedMessage, meta);
+      this.graylog2Client[getMessageLevel(level)](shortMessage, info.stack ?? cleanedMessage, meta);
     });
     callback();
   }


### PR DESCRIPTION
When logging an error object, Graylog currently receives only the error message.
The stack trace is very useful to easily locate the error. I propose to send the stack of the error as full_message, if it is available, as it contains both, the message and the trace.